### PR TITLE
Bind events on window, when we don't have a scrollabel object

### DIFF
--- a/jquery.onimpression.js
+++ b/jquery.onimpression.js
@@ -4,7 +4,7 @@
   *
   * Licensed under the MIT license.
   *
-  * Inspired by Luís Almeida's Unveil https://github.com/luis-almeida
+  * Inspired by LuÃ­s Almeida's Unveil https://github.com/luis-almeida
 **/
 ; (function ($) {
     $.fn.onImpression = function (options) {
@@ -58,9 +58,10 @@
 
         // Only run  code if the callback is available, else there is no point
         if (typeof settings.callback === "function") {
-            $window.on("scroll.onImpression resize.onImpression lookup.onImpression", onImpression);
             if ($scrollable.length) {
                 $scrollable.on("scroll.onImpression resize.onImpression lookup.onImpression", onImpression);
+            }else {
+                $window.on("scroll.onImpression resize.onImpression lookup.onImpression", onImpression);
             }
             onImpression();
         }


### PR DESCRIPTION
It doesn't really make sense to bind all the events to the window object if we are not using it? In my case I have a scrollable area and the plugin should only listen to events on it, not on the whole window.
